### PR TITLE
Fix import error when labs-adk is unavailable

### DIFF
--- a/src/evo_ai/__init__.py
+++ b/src/evo_ai/__init__.py
@@ -1,7 +1,17 @@
-from labs.adk.agent_loader import AgentLoader
+"""Package initialization for :mod:`evo_ai`."""
+
+import logging
+
+try:
+    from labs.adk.agent_loader import AgentLoader
+except Exception:  # pragma: no cover - optional dependency
+    AgentLoader = None
+    logging.getLogger(__name__).warning(
+        "labs-adk not available; AgentLoader functionality disabled"
+    )
 
 from . import fake_data, function_tools
 
 __all__ = ["fake_data", "function_tools"]
 
-root_agent = AgentLoader(__name__)
+root_agent = AgentLoader(__name__) if AgentLoader else None


### PR DESCRIPTION
## Summary
- allow importing `evo_ai` without labs-adk installed

## Testing
- `pip install -q python-dotenv plotly pandas numpy kaleido google-cloud-aiplatform google-genai`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68818f6a952c832891e96e5fb61e8393